### PR TITLE
Fix active_record spelling

### DIFF
--- a/lib/crowd_pay.rb
+++ b/lib/crowd_pay.rb
@@ -1,4 +1,4 @@
-require 'activerecord'
+require 'active_record'
 
 module CrowdPay
   autoload :Base,        'crowd_pay/base'


### PR DESCRIPTION
Change "activerecord" to "active_record" in the crowd_pay.rb require statement